### PR TITLE
fix(footer): remove "Inc." from copyright notice

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -90,7 +90,7 @@ export function Footer() {
         </div>
         <div className="mt-12 mb-10 flex flex-wrap items-end justify-end gap-x-6 gap-y-4 border-t border-neutral-950/10 pt-12">
           <p className="text-xs text-neutral-700">
-            © KONDAX Inc. {new Date().getFullYear()}
+            © KONDAX {new Date().getFullYear()}
           </p>
         </div>
       </FadeIn>


### PR DESCRIPTION
KONDAX is not incorporated (About page states 代表 / 個人事業主),
so the footer copyright should read "© KONDAX <year>".

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01NsD3P1KvFcSdfZay6RLoQA