### PR TITLE
Yadora画像に浮遊アニメーションと角丸を追加

### DIFF
--- a/docs/plans/2026-08-23-yadora-visual-refresh-design.md
+++ b/docs/plans/2026-08-23-yadora-visual-refresh-design.md
@@ -9,7 +9,7 @@ Replace the synthetic dashboard, glow effects, pill badges, and repeated icon ca
 - Palette: warm paper, charcoal, Yadora forest green, and a small amber accent sampled from the screenshot.
 - Composition: strong typographic hierarchy, wide image crops, hairline rules, asymmetrical grids, and generous negative space.
 - Components: numbered editorial rows instead of card grids; square corners and subtle borders instead of repeated oversized radii.
-- Motion: keep the existing quiet reveal animation, with no decorative hover movement or glow.
+- Motion: keep the quiet reveal animation and add one restrained floating product-image moment, with no glow or scattered decorative movement.
 
 ## Page changes
 
@@ -25,3 +25,10 @@ Replace the synthetic dashboard, glow effects, pill badges, and repeated icon ca
 - Desktop and mobile browser review, including overflow and image legibility.
 - Japanese and English content checks.
 - Old Bocker URL redirect remains unchanged.
+
+## Motion follow-up
+
+- Float the Yadora product image vertically by 12px on a slow 5.8-second cycle.
+- Pair the movement with a synchronized soft ground shadow so the image feels suspended rather than merely translated.
+- Use rounded outer and inner frames to soften the product screenshot without returning to card-heavy UI.
+- Disable continuous movement automatically when the visitor prefers reduced motion.

--- a/src/app/[locale]/work/page.tsx
+++ b/src/app/[locale]/work/page.tsx
@@ -61,9 +61,13 @@ async function FeaturedYadora({ locale }: { locale: string }) {
             <Link
               href="/work/yadora"
               aria-label={t('featured.button')}
-              className="block border border-neutral-800 bg-[#111311] p-1.5 shadow-[0_24px_60px_rgba(17,19,17,0.16)] focus-visible:ring-2 focus-visible:ring-neutral-950 focus-visible:ring-offset-4 focus-visible:outline-none sm:p-2"
+              className="relative isolate block rounded-[1.75rem] border border-neutral-800 bg-[#111311] p-1.5 shadow-[0_28px_70px_rgba(17,19,17,0.18),0_10px_24px_rgba(17,19,17,0.1)] focus-visible:ring-2 focus-visible:ring-neutral-950 focus-visible:ring-offset-4 focus-visible:outline-none motion-safe:animate-yadora-float motion-safe:will-change-transform sm:rounded-[2rem] sm:p-2"
             >
-              <div className="relative aspect-[1306/777] overflow-hidden bg-[#151816]">
+              <span
+                aria-hidden="true"
+                className="absolute right-[8%] -bottom-5 left-[8%] -z-10 h-8 rounded-full bg-neutral-950/25 blur-2xl motion-safe:animate-yadora-shadow"
+              />
+              <div className="relative aspect-[1306/777] overflow-hidden rounded-[1.35rem] bg-[#151816] sm:rounded-[1.55rem]">
                 <Image
                   src="/images/yadora/yadora-hero.png"
                   alt=""

--- a/src/components/YadoraShowcase.tsx
+++ b/src/components/YadoraShowcase.tsx
@@ -220,9 +220,13 @@ export async function YadoraShowcase({ locale }: { locale: string }) {
           </div>
 
           <FadeIn className="mt-14 sm:mt-18">
-            <figure>
-              <div className="border border-neutral-800 bg-[#111311] p-1.5 shadow-[0_32px_80px_rgba(17,19,17,0.18)] sm:p-2.5">
-                <div className="relative aspect-[1306/777] overflow-hidden bg-[#151816]">
+            <figure className="relative">
+              <div
+                aria-hidden="true"
+                className="absolute right-[8%] -bottom-1 left-[8%] h-8 rounded-full bg-neutral-950/30 blur-2xl motion-safe:animate-yadora-shadow"
+              />
+              <div className="relative overflow-hidden rounded-[1.75rem] border border-neutral-800 bg-[#111311] p-1.5 shadow-[0_36px_90px_rgba(17,19,17,0.2),0_12px_30px_rgba(17,19,17,0.12)] motion-safe:animate-yadora-float motion-safe:will-change-transform sm:rounded-[2.25rem] sm:p-2.5">
+                <div className="relative aspect-[1306/777] overflow-hidden rounded-[1.35rem] bg-[#151816] sm:rounded-[1.75rem]">
                   <Image
                     src={productImage}
                     alt={t('intro.imageAlt')}
@@ -233,7 +237,7 @@ export async function YadoraShowcase({ locale }: { locale: string }) {
                   />
                 </div>
               </div>
-              <figcaption className="mt-4 flex items-center justify-between gap-4 text-[10px] font-semibold tracking-[0.2em] text-neutral-400 uppercase sm:text-xs">
+              <figcaption className="mt-6 flex items-center justify-between gap-4 text-[10px] font-semibold tracking-[0.2em] text-neutral-400 uppercase sm:mt-7 sm:text-xs">
                 <span>{t('intro.imageCaption')}</span>
                 <span aria-hidden="true">KONDAX × Yadora</span>
               </figcaption>

--- a/src/styles/tailwind.css
+++ b/src/styles/tailwind.css
@@ -46,6 +46,30 @@
   --animate-float: float-random 12s ease-in-out infinite;
   --animate-float-tilt: float-tilt 8s ease-in-out infinite;
   --animate-slime: slime-morph 12s ease-in-out infinite;
+  --animate-yadora-float: yadora-float 5.8s ease-in-out infinite;
+  --animate-yadora-shadow: yadora-shadow 5.8s ease-in-out infinite;
+}
+
+@keyframes yadora-float {
+  0%,
+  100% {
+    transform: translate3d(0, 0, 0);
+  }
+  50% {
+    transform: translate3d(0, -12px, 0);
+  }
+}
+
+@keyframes yadora-shadow {
+  0%,
+  100% {
+    opacity: 0.32;
+    transform: scaleX(1);
+  }
+  50% {
+    opacity: 0.18;
+    transform: scaleX(0.88);
+  }
 }
 
 @keyframes float-random {


### PR DESCRIPTION
## 概要
- Yadora主画像に5.8秒周期・最大12pxの穏やかな浮遊アニメーションを追加
- 動きに合わせて接地影の濃さと幅を同期
- 詳細ページと制作実績一覧の画像を大きめの角丸へ変更
- 動きを減らす設定ではアニメーションと合成レイヤーを無効化

## 確認
- Node 22でNext.js本番ビルド成功
- PC 1330px / スマホ 390pxで表示確認
- アニメーション名・周期・移動量・角丸をブラウザ上で確認
- 横スクロール、Next.jsエラー表示なし
- 外部レビューでCritical/Importantなし